### PR TITLE
Change Cargo's requirement of `criterion'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ getopts = "0.2.14"
 bit-vec = "0.4.3"
 
 [dev-dependencies]
-criterion = { git = "http://github.com/sga001/criterion.rs" }
+criterion = { git = "http://github.com/japaric/criterion.rs" }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
In pung's release version, it uses a modified version of `criterion', which can be found here: https://github.com/sga001/criterion.rs

This modified version uses criterion-stats = { git = "https://github.com/japaric/stats.rs" }

Yet, due to library refactoring, criterion-stats has been merged to the criterion library. Sees this message from the original repo's README:  

```
This repository formerly contained the statistics sub-crate for Criterion.rs. It has been merged (with full history) into the main repository.
```