### PR TITLE
Update deprecated  code segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [build-dependencies]
 capnpc = "0.7.3"
-gcc = "0.3.41"
+cc = "1.0"
 cmake = "0.1.20"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate capnpc;
-extern crate gcc;
+extern crate cc;
 extern crate cmake;
 
 fn main() {
@@ -12,7 +12,7 @@ fn main() {
 
 
     // Compile and link pung C++ PIR shim
-    gcc::Build::new()
+    cc::Build::new()
                  .file("src/pir/cpp/pungPIR.cpp")
                  .include("deps/xpir/")
                  .flag("-std=c++11")

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -149,18 +149,18 @@ pub fn main() {
             client.add_peer(&peer_name, &secret);
 
             // Register with the service
-            let unique_id: u64 = try!(client.register(&wait_scope, &mut event_port));
+            let unique_id: u64 = (client.register(&wait_scope, &mut event_port))?;
             println!("{} - Registered with Pung server", unique_id);
 
             // Changing the extra tuple value at the server (if requested).
             if extra > 0 {
-                try!(client.extra(extra, &wait_scope, &mut event_port));
+                client.extra(extra, &wait_scope, &mut event_port)?;
                 println!("{} - Changing the extra tuples value at Pung server to {}", unique_id, extra);
             }
 
             // Get current round number
             println!("{} - Synchronizing with the Pung server", unique_id);
-            try!(client.sync(&wait_scope, &mut event_port));
+            client.sync(&wait_scope, &mut event_port)?;
 
             //        std::thread::sleep(std::time::Duration::new(5, 0));
 
@@ -180,7 +180,7 @@ pub fn main() {
                 let start = PreciseTime::now();
 
                 // send tuple
-                try!(client.send(&peer_name, &mut messages, &wait_scope, &mut event_port));
+                client.send(&peer_name, &mut messages, &wait_scope, &mut event_port)?;
 
                 let end = PreciseTime::now();
                 let duration = start.to(end);
@@ -200,7 +200,7 @@ pub fn main() {
                     peers.push(&peer_name);
                 }
 
-                let msgs = try!(client.retr(&peers[..], &wait_scope, &mut event_port));
+                let msgs = client.retr(&peers[..], &wait_scope, &mut event_port)?;
 
                 let end = PreciseTime::now();
                 println!("retr ({} msgs): {:?} usec",
@@ -218,7 +218,7 @@ pub fn main() {
             let duration = start_round.to(end_round);
             println!("processed {} rounds in {} usec", rounds, duration.num_microseconds().unwrap());
 
-            try!(client.close(&wait_scope, &mut event_port));
+            client.close(&wait_scope, &mut event_port)?;
 
             Ok(())
         })

--- a/src/pir/pir_client.rs
+++ b/src/pir/pir_client.rs
@@ -11,35 +11,35 @@ use super::{PirQuery, PirResult};
 // #[link(name = "boost_system")]
 extern "C" {
     fn cpp_client_setup(
-        len: libc::uint64_t,
-        num: libc::uint64_t,
-        alpha: libc::uint64_t,
-        depth: libc::uint64_t,
+        len: u64,
+        num: u64,
+        alpha: u64,
+        depth: u64,
     ) -> *mut libc::c_void;
 
     fn cpp_client_generate_query(
         client: *const libc::c_void,
-        index: libc::uint64_t,
-        q_len: *mut libc::uint64_t,
-        q_num: *mut libc::uint64_t,
-    ) -> *mut libc::uint8_t;
+        index: u64,
+        q_len: *mut u64,
+        q_num: *mut u64,
+    ) -> *mut u8;
 
     fn cpp_client_process_reply(
         client: *const libc::c_void,
-        answer: *const libc::uint8_t,
-        a_len: libc::uint64_t,
-        a_num: libc::uint64_t,
-        r_len: *mut libc::uint64_t,
-    ) -> *mut libc::uint8_t;
+        answer: *const u8,
+        a_len: u64,
+        a_num: u64,
+        r_len: *mut u64,
+    ) -> *mut u8;
 
     fn cpp_client_free(client: *mut libc::c_void);
 
     fn cpp_client_update_db_params(
         client: *const libc::c_void,
-        len: libc::uint64_t,
-        num: libc::uint64_t,
-        alpha: libc::uint64_t,
-        depth: libc::uint64_t,
+        len: u64,
+        num: u64,
+        alpha: u64,
+        depth: u64,
     );
 }
 

--- a/src/pir/pir_server.rs
+++ b/src/pir/pir_server.rs
@@ -11,21 +11,21 @@ use super::PirAnswer;
 //#[link(name = "boost_system")]
 extern "C" {
     fn cpp_server_setup(
-        len: libc::uint64_t,
-        collection: *const libc::uint8_t,
-        num: libc::uint64_t,
-        alpha: libc::uint64_t,
-        depth: libc::uint64_t,
+        len: u64,
+        collection: *const u8,
+        num: u64,
+        alpha: u64,
+        depth: u64,
     ) -> *mut libc::c_void;
 
     fn cpp_server_process_query(
         server: *const libc::c_void,
-        q: *const libc::uint8_t,
-        q_len: libc::uint64_t,
-        q_num: libc::uint64_t,
-        a_len: *mut libc::uint64_t, // answer length
-        a_num: *mut libc::uint64_t,
-    ) -> *mut libc::uint8_t;
+        q: *const u8,
+        q_len: u64,
+        q_num: u64,
+        a_len: *mut u64, // answer length
+        a_num: *mut u64,
+    ) -> *mut u8;
 
     fn cpp_server_free(server: *mut libc::c_void);
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -93,12 +93,12 @@ pub fn run_rpc(
 
     gj::EventLoop::top_level(move |wait_scope| -> Result<(), capnp::Error> {
         // create event port
-        let mut event_port = try!(gjio::EventPort::new());
+        let mut event_port = gjio::EventPort::new()?;
         let network = event_port.get_network();
         let mut address = network.get_tcp_address(addr);
 
         // create a listener for Pung's RPC server
-        let listener = try!(address.listen());
+        let listener = address.listen()?;
 
         // instance of the pung RPC server
         let connection = pung_rpc::ToClient::new(PungRpc::new(
@@ -113,7 +113,7 @@ pub fn run_rpc(
         // defines a set that holds all promises ("tasks") and a destructor in case they go awry
         let task_set = gj::TaskSet::new(Box::new(reaper::Reaper));
 
-        try!(accept_loop(listener, task_set, connection).wait(wait_scope, &mut event_port));
+        accept_loop(listener, task_set, connection).wait(wait_scope, &mut event_port)?;
 
         Ok(())
     }).expect("top level error running server RPC");


### PR DESCRIPTION
The `try!` macro has been deprectaed in Rust. Replaced it with the `?` operator.

The `gcc` crate is deprectaed and renamed as `cc`. Updated accordingly.